### PR TITLE
Optimize LLM inputs

### DIFF
--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/lms_log_analyzer/src/llm_handler.py
@@ -143,12 +143,6 @@ def _trim_alert(alert: Dict[str, Any]) -> Dict[str, Any]:
     original = alert.get("full_log") or alert.get("original_log")
     if original:
         trimmed["original_log"] = original
-    agent_name = alert.get("agent", {}).get("name")
-    if agent_name:
-        trimmed.setdefault("agent", {})["name"] = agent_name
-    manager_name = alert.get("manager", {}).get("name")
-    if manager_name:
-        trimmed.setdefault("manager", {})["name"] = manager_name
     data = alert.get("data", {})
     for key in ("srcip", "dstip", "srcport", "dstport"):
         value = data.get(key)
@@ -159,14 +153,14 @@ def _trim_alert(alert: Dict[str, Any]) -> Dict[str, Any]:
 
 def _summarize_examples(examples: List[Dict[str, Any]]) -> str:
 
-
     parts = []
     for ex in examples:
-        log = str(ex.get("log", "")).replace("\n", " ")
         analysis = ex.get("analysis", {})
         attack_type = analysis.get("attack_type", "")
         reason = analysis.get("reason", "")
-        parts.append(f"{log} | {attack_type} | {reason}".strip())
+        if not attack_type and not reason:
+            continue
+        parts.append(f"歷史攻擊: {attack_type} | 理由: {reason}".strip())
     return "\n".join(parts)
 
 

--- a/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
+++ b/MCP_lms_log_analyzer/EDGE-codex-refactor-lms_log_analyzer_v2-into-modular-project/tests/test_llm_handler.py
@@ -33,6 +33,10 @@ class LLMHandlerTest(unittest.TestCase):
             {"log": "line2", "analysis": {"attack_type": "mal", "reason": "y"}},
         ]
 
+        summary = llm_handler._summarize_examples(examples)
+        self.assertNotIn("line1", summary)
+        self.assertIn("歷史攻擊: phish | 理由: x", summary)
+        self.assertIn("歷史攻擊: mal | 理由: y", summary)
 
     def test_llm_analyse_caches_and_summarizes(self):
         example = {
@@ -46,7 +50,9 @@ class LLMHandlerTest(unittest.TestCase):
 
         llm_handler.LLM_CHAIN.batch.assert_called_once()
         sent = llm_handler.LLM_CHAIN.batch.call_args.args[0][0]["examples_summary"]
-        self.assertIn("bad log", sent)
+        self.assertNotIn("bad log", sent)
+        self.assertIn("sql", sent)
+        self.assertIn("r", sent)
         alert_json = llm_handler.LLM_CHAIN.batch.call_args.args[0][0]["alert_json"]
         self.assertIn("\"id\": 1", alert_json)
 


### PR DESCRIPTION
## Summary
- trim irrelevant agent and manager fields from alert JSON
- shorten example summaries to only include attack type and reason
- adjust tests for the new summarization format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c4c4a8cf08320ba952bccbc760060